### PR TITLE
Reduce produce time by batching 1 message at a time

### DIFF
--- a/internal/client/producer.go
+++ b/internal/client/producer.go
@@ -27,6 +27,7 @@ func NewProducerClient(config ConnectorConfig, topic string) (*ProducerClient, e
 		Addr:      kafka.TCP(connector.Config.BrokerAddrs...),
 		Transport: connector.KafkaClient.Transport,
 		Topic:     topic,
+		BatchSize: 1, // We always want to write 1 by 1 for this client, as its use for canary
 	}
 
 	return &ProducerClient{


### PR DESCRIPTION
The default value for `BatchSize` is 100, which is great for common production workloads but not for the canary.