### PR TITLE
Add dash to replacer

### DIFF
--- a/cmd/kafka-canary/main.go
+++ b/cmd/kafka-canary/main.go
@@ -149,7 +149,7 @@ func parseConfigFile() {
 
 func parseEnvVariables() {
 	viper.SetEnvPrefix("KAFKA_CANARY")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 }
 


### PR DESCRIPTION
Currently a lot of the configs use "-" in their references and this causes the env vars to not properly sync.