### PR TITLE
Add default Helm mem/cpu

### DIFF
--- a/charts/kafka-canary/values.yaml
+++ b/charts/kafka-canary/values.yaml
@@ -37,7 +37,13 @@ service:
   port: 9898
   annotations: {}
 
-resources: {}
+resources:
+  requests:
+    cpu: 1
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
Prevent the service from consuming an absurd amount of resources if rate is set too high.