### PR TITLE
Set minISR to Replicas-1

### DIFF
--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -165,9 +165,10 @@ func (s topicService) Close() {
 func (s *topicService) reconcileConfiguration(ctx context.Context, brokers []client.BrokerInfo) error {
 	brokersNumber := len(brokers)
 	replicationFactor := min(brokersNumber, 3)
+	minISR := max(1, replicationFactor-1)
 	configs := map[string]string{
 		"cleanup.policy":      cleanupPolicy,
-		"min.insync.replicas": strconv.Itoa(replicationFactor),
+		"min.insync.replicas": minISR,
 	}
 
 	err := s.admin.UpdateTopicConfig(ctx, s.canaryConfig.Topic, configs)
@@ -266,11 +267,12 @@ func (s *topicService) getTopic(ctx context.Context) (*client.TopicInfo, error) 
 func (s *topicService) createTopic(ctx context.Context, brokers []client.BrokerInfo) error {
 	brokersNumber := len(brokers)
 	replicationFactor := min(brokersNumber, 3)
+	minISR := max(1, replicationFactor-1)
 
 	assignments := s.requestAssignments(ctx, 0, brokers)
 	configs := map[string]string{
 		"cleanup.policy":      cleanupPolicy,
-		"min.insync.replicas": strconv.Itoa(replicationFactor),
+		"min.insync.replicas": minISR,
 	}
 
 	if err := s.admin.CreateTopic(ctx, s.canaryConfig.Topic, assignments, configs); err != nil {

--- a/internal/services/topic.go
+++ b/internal/services/topic.go
@@ -168,7 +168,7 @@ func (s *topicService) reconcileConfiguration(ctx context.Context, brokers []cli
 	minISR := max(1, replicationFactor-1)
 	configs := map[string]string{
 		"cleanup.policy":      cleanupPolicy,
-		"min.insync.replicas": minISR,
+		"min.insync.replicas": strconv.Itoa(minISR),
 	}
 
 	err := s.admin.UpdateTopicConfig(ctx, s.canaryConfig.Topic, configs)
@@ -272,7 +272,7 @@ func (s *topicService) createTopic(ctx context.Context, brokers []client.BrokerI
 	assignments := s.requestAssignments(ctx, 0, brokers)
 	configs := map[string]string{
 		"cleanup.policy":      cleanupPolicy,
-		"min.insync.replicas": minISR,
+		"min.insync.replicas": strconv.Itoa(minISR),
 	}
 
 	if err := s.admin.CreateTopic(ctx, s.canaryConfig.Topic, assignments, configs); err != nil {


### PR DESCRIPTION
This fixes a bug in which the number of minISR was set to be equal to the number of replicas. Causing partitions to offline unnecessary causing false alerts.