### PR TITLE
Increase lint timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          args: --timeout=10m


### PR DESCRIPTION
```
  Running [/home/runner/golangci-lint-1.53.3-linux-amd64/golangci-lint run --out-format=github-actions --new-from-patch=/tmp/tmp-1770-VqyZpIOy7cEX/pull.patch --new=false --new-from-rev=] in [] ...
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
  
  Error: golangci-lint exit with code 4
```